### PR TITLE
Deserialization of tuple structs and IgnoredAny

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -289,10 +289,12 @@ impl<'de, 'a> de::Deserializer<'de> for MapKey<'a, 'de> {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        // Even if we’re ignoring the contents of the map, we still need to
+        // deserialize the string here in order to chomp the key’s characters.
+        self.deserialize_str(visitor)
     }
 }


### PR DESCRIPTION
The derived Deserialize implementation expects to be able to generate
tuple structs from arrays, so this implements deserialize_tuple_struct
to delegate to deserialize_seq.

Also implements deserialize_ignored_any so that Deserializers can
ignore fields of objects that they don’t care about.

Includes some comments explaining why certain deserialize methods are
unimplemented (I chose to use comments rather than passing a string
to unreachable! so that the strings wouldn’t end up in the binary).

Also adds a "CustomError" enum so that errors generated from the
derive macro don’t cause a panic. (And includes a note that maybe we
could put a heapless String there.)